### PR TITLE
feat: variablize the ecr endpoint policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ To view examples for how you can leverage this VPC Module, please see the [examp
 | [aws_ec2_subnet_cidr_reservation.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_subnet_cidr_reservation) | resource |
 | [aws_security_group.vpc_smtp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.vpc_tls](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
-| [aws_iam_policy_document.ecr](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_security_group.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group) | data source |
 
@@ -48,6 +47,7 @@ To view examples for how you can leverage this VPC Module, please see the [examp
 | <a name="input_create_database_subnet_group"></a> [create\_database\_subnet\_group](#input\_create\_database\_subnet\_group) | Create database subnet group | `bool` | `true` | no |
 | <a name="input_create_default_vpc_endpoints"></a> [create\_default\_vpc\_endpoints](#input\_create\_default\_vpc\_endpoints) | Creates a default set of VPC endpoints. | `bool` | `true` | no |
 | <a name="input_database_subnets"></a> [database\_subnets](#input\_database\_subnets) | List of database subnets inside the VPC | `list(string)` | `[]` | no |
+| <a name="input_ecr_endpoint_policy"></a> [ecr\_endpoint\_policy](#input\_ecr\_endpoint\_policy) | Policy to attach to the ECR endpoint. Defaults to *. | `string` | `null` | no |
 | <a name="input_enable_fips_vpce"></a> [enable\_fips\_vpce](#input\_enable\_fips\_vpce) | Enable FIPS endpoints for VPC endpoints. | `bool` | `false` | no |
 | <a name="input_enable_nat_gateway"></a> [enable\_nat\_gateway](#input\_enable\_nat\_gateway) | Enable NAT gateway | `bool` | `false` | no |
 | <a name="input_flow_log_cloudwatch_log_group_retention_in_days"></a> [flow\_log\_cloudwatch\_log\_group\_retention\_in\_days](#input\_flow\_log\_cloudwatch\_log\_group\_retention\_in\_days) | Specifies the number of days you want to retain log events in the specified log group for VPC flow logs | `number` | `365` | no |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -35,6 +35,7 @@ Example that uses the module with many of its configurations. Used in CI E2E tes
 |------|------|
 | [random_id.default](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
+| [aws_iam_policy_document.ecr](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 

--- a/main.tf
+++ b/main.tf
@@ -1,56 +1,5 @@
 data "aws_region" "current" {}
 
-data "aws_iam_policy_document" "ecr" {
-  # checkov:skip=CKV_AWS_283: This policy allows EKS to access the regional ecr via a private VPC endpoint.
-  # checkov:skip=CKV_AWS_111: Cannot constrain down resources without knowing specific ECR Repo information.
-  statement {
-    effect = "Allow"
-
-    actions = [
-      "ecr:GetAuthorizationToken",
-      "ecr:BatchCheckLayerAvailability",
-      "ecr:GetDownloadUrlForLayer",
-      "ecr:BatchGetImage",
-      "ecr:DescribeImages",
-      "ecr:ListImages",
-      "ecr:PutImage",
-      "ecr:CreateRepository",
-      "ecr:InitiateLayerUpload",
-      "ecr:UploadLayerPart",
-      "ecr:CompleteLayerUpload",
-      "ecr:DeleteRepository",
-      "ecr:TagResource",
-      "ecr:describeRepo",
-      "ecr:DescribeRepositories"
-    ]
-
-    principals {
-      type        = "AWS"
-      identifiers = ["*"]
-    }
-
-    resources = ["*"]
-  }
-
-  statement {
-    effect    = "Deny"
-    actions   = ["*"]
-    resources = ["*"]
-
-    principals {
-      type        = "*"
-      identifiers = ["*"]
-    }
-
-    condition {
-      test     = "StringNotEquals"
-      variable = "aws:SourceVpc"
-
-      values = [module.vpc.vpc_id]
-    }
-  }
-}
-
 locals {
 
   tags = merge(
@@ -214,7 +163,7 @@ module "vpc_endpoints" {
       private_dns_enabled = true
       subnet_ids          = module.vpc.private_subnets
       security_group_ids  = [aws_security_group.vpc_tls[0].id]
-      policy              = data.aws_iam_policy_document.ecr.json
+      policy              = var.ecr_endpoint_policy
     },
     ecr_dkr = {
       service             = "ecr.dkr"
@@ -222,7 +171,7 @@ module "vpc_endpoints" {
       private_dns_enabled = true
       subnet_ids          = module.vpc.private_subnets
       security_group_ids  = [aws_security_group.vpc_tls[0].id]
-      policy              = data.aws_iam_policy_document.ecr.json
+      policy              = var.ecr_endpoint_policy
     },
     kms = {
       service             = "kms"

--- a/variables.tf
+++ b/variables.tf
@@ -129,6 +129,12 @@ variable "create_default_vpc_endpoints" {
   default     = true
 }
 
+variable "ecr_endpoint_policy" {
+  description = "Policy to attach to the ECR endpoint. Defaults to *."
+  type        = string
+  default     = null
+}
+
 variable "enable_fips_vpce" {
   description = "Enable FIPS endpoints for VPC endpoints."
   type        = bool


### PR DESCRIPTION
Allows the ECR endpoint policies (api & dkr) to be overridden `policy   = var.ecr_endpoint_policy`. It defaults to a allow any policy to match the other vpce policies.